### PR TITLE
Fix off-by-one bug at length check

### DIFF
--- a/src/jquery.textarea-maxlength-shim.js
+++ b/src/jquery.textarea-maxlength-shim.js
@@ -5,8 +5,8 @@ if (!("maxLength" in document.createElement("textarea"))) {
                 that = this,
                 limit = Math.abs(parseInt($el.attr("maxlength"), 10)) || -1;
             if (keyCode === 13 || keyCode >= 33) {
-                if (that.value.length >= limit) {
-                    that.value = that.value.substr(0, limit - 1);
+                if (that.value.length > limit) {
+                    that.value = that.value.substr(0, limit);
                     event.preventDefault();
                 }
             }


### PR DESCRIPTION
It sliced too much and the if didn't have to check for equality.

Another go at it. The original PR got closed inadvertently due to git modifications.

Note that you'll still want to try this out across various browsers! I encountered the original issue at Chrome. If the fix is ok, remember to generate `dist` (grunt refresh).
